### PR TITLE
Vesion 2.0 of WS2812 library

### DIFF
--- a/CoreTimer.c
+++ b/CoreTimer.c
@@ -57,6 +57,12 @@
 
 #define TICKSPERSHORTCHECK  (5 * CORE_TICK_RATE)        // 5ms
 #define TICKSPERREFRESH     (30 * CORE_TICK_RATE)       // 30ms
+/* This is the clock rate for the SPI port. This is the fundamental unit that
+ * the 1 and 0 high and low times are expressed in. This value of 3MHz was
+ * picked because it allows for a low error rate on the various chipKIT
+ * boards, and it still allows the timing requirements of the WS2812 LEDs to
+ * be met. */
+#define WS2812_SPI_CLOCK_RATE   (3000000)
 
 #define KVA_2_PA(v) (((uint32_t) (v)) & 0x1fffffff)
 #define read_count(dest) __asm__ __volatile__("mfc0 %0,$9" : "=r" (dest))
@@ -130,7 +136,7 @@ uint32_t WS2812TimerService(uint32_t curTime)
  *                          the WS2812 would normally take. By default, the is "false".
  *
  *    Return Values:
- *          True if the core timer can be aquired and initialization succeeded.
+ *          True if the core timer can be acquired and initialization succeeded.
  *
  *    Description:
  *
@@ -140,7 +146,7 @@ uint32_t WS2812TimerService(uint32_t curTime)
  *
  *      Also, initialize 2 DMA channels, one to shift out
  *      the pattern buffer, the other to maintain zeros
- *      for the restart / reset patteren (RES).
+ *      for the restart / reset pattern (RES).
  *
  * ------------------------------------------------------------ */
 uint32_t InitWS2812(uint8_t * pPatternBuffer, uint32_t cbPatternBuffer, uint32_t fInvert)
@@ -155,8 +161,8 @@ uint32_t InitWS2812(uint8_t * pPatternBuffer, uint32_t cbPatternBuffer, uint32_t
     SPI2CONbits.STXISEL = 0b10; // trigger DMA event when the ENBUF is half empty
 //    SPI2CONbits.DISSDI  = 1;  // Disable the SDI pin, allow it to be used for GPIO (not implemented on an MX6)
     SPI2STAT            = 0;    // clear status register
-    SPI2BRG             = (__PIC32_pbClk / (2 * 20000000)) - 1;  // 20MHz, 50ns
-
+    SPI2BRG             = (__PIC32_pbClk / (2 * WS2812_SPI_CLOCK_RATE)) - 1;
+    
     IEC1bits.SPI2RXIE   = 0;    // disable SPI interrupts
     IEC1bits.SPI2TXIE   = 0;    // disable SPI interrupts
     IEC1bits.SPI2EIE    = 0;    // disable SPI interrupts
@@ -186,8 +192,14 @@ uint32_t InitWS2812(uint8_t * pPatternBuffer, uint32_t cbPatternBuffer, uint32_t
 
     DCH0INT             = 0;    // do not trigger any events
     DCH0INTbits.CHBCIF  = 0;    // clear IF bit
+
+#if defined(_BOARD_FUBARINO_MINI_)
+    IPC10bits.DMA0IP     = 7;    // priority 7
+    IPC10bits.DMA1IS     = 0;    // sub priority 0
+#else
     IPC9bits.DMA0IP     = 7;    // priority 7
     IPC9bits.DMA1IS     = 0;    // sub priority 0
+#endif
 
     DCH0SSA             = KVA_2_PA(pPatternBuffer); // source address of transfer
     DCH0SSIZ            = cbPatternBuffer;          // number of bytes in source
@@ -223,7 +235,7 @@ uint32_t InitWS2812(uint8_t * pPatternBuffer, uint32_t cbPatternBuffer, uint32_t
     DCH1DSIZ            = 1;                    // 1 byte at the destination
     DCH1CSIZ            = 1;                    // only transfer 1 byte per event
 
-    // initial time for the core serivce routine
+    // initial time for the core service routine
     read_count(tWS2812LastRun);
 
     // attach the core service routine

--- a/WS2812.h
+++ b/WS2812.h
@@ -34,10 +34,11 @@
 /*  Revision History:                                                   */
 /*                                                                      */
 /*    5/1/2014(KeithV): Created                                         */
+/*    9/8/2015 (BPS): Updated for more accurate timing and less RAM     */
 /************************************************************************/
 /************************************************************************/
 /*                                                                      */
-/*  Supports the WS2812 signalling to drive up to 1000 devices           */
+/*  Supports the WS2812 signalling to drive up to 1000 devices          */
 /*                                                                      */
 /************************************************************************/
 /************************************************************************/
@@ -63,7 +64,11 @@
 
 /* CPUs with _DMAC defined have DMA. */
 #if !defined(_DMAC)
-#error Board does not support needed DMA or SPI resources
+  #if defined(__PIC32MZ__)
+    #error PIC32MZ based chipKIT boards are not yet supported by this library.
+  #else
+    #error Board does not support needed DMA or SPI resources
+  #endif
 #endif
 
 /*

--- a/WS2812.h
+++ b/WS2812.h
@@ -37,7 +37,7 @@
 /************************************************************************/
 /************************************************************************/
 /*                                                                      */
-/*  Supports the WS2812 signaling to drive up to 1000 devices           */
+/*  Supports the WS2812 signalling to drive up to 1000 devices           */
 /*                                                                      */
 /************************************************************************/
 /************************************************************************/
@@ -61,13 +61,53 @@
 /************************************************************************/
 #include <WProgram.h>
 
-#if !(defined(_BOARD_WF32_) ||  defined(_BOARD_FUBARINO_SD_)|| defined(_BOARD_MEGA_))
+/* CPUs with _DMAC defined have DMA. */
+#if !defined(_DMAC)
 #error Board does not support needed DMA or SPI resources
 #endif
 
-// use this define to provide a pattern buffer big enough
-// to support the number of devices in the string.
-#define CBWS2812PATBUF(__cDevices)  (78 * __cDevices)
+/*
+ * Measured times (as per https://cpldcpu.wordpress.com/2014/01/14/light_ws2812-library-v2-0-part-i-understanding-the-ws2812/)
+ * are 1.25uS to 9uS for a single cycle (1 or 0)
+ * A '0' should be high from between 62.5nS to 500nS
+ * A '1' should be high from between 625nS to almost 1.25uS (entire bit cycle time) 
+ *
+ * Ideal times (as per LED spec are)
+ * WS2812/WS2812S
+ *   0 high = 350nS +/- 150nS
+ *   1 high = 800nS +/- 150nS
+ *   0 low = 800nS  +/- 150nS
+ *   1 low = 600nS  +/- 150nS
+ * Total bit time = 1250nS +/- 600nS
+ *
+ * WS2812B
+ *   0 high = 350nS +/- 150nS
+ *   1 high = 900nS +/- 150nS
+ *   0 low = 900nS  +/- 150nS
+ *   1 low = 350nS  +/- 150nS
+ * Total bit time = 1250nS +/- 150nS
+ */
+
+/* This is the number of SPI clocks per 1 or 0 being sent out to the LED. You MUST
+ * change this value if you change WS2812_SPI_CLOCK_RATE in CoreTimer.c to maintain
+ * the necessary timing per 1 or 0. With a 3MHz SPI clock, we use a 1 high time of 
+ * 1 SPI clock, a 0 high time of 2 SPI clocks, and a total bit time of 4 SPI clocks.
+ *
+ * You must also change this value if you increase the WS2812_DEFAULT_BIT_WIDTH_CLKS
+ * value below, or if you pass in a new cBitWidth value to begin() that's bigger.
+ *
+ * Normally this value should be set to the same number as WS2812_DEFAULT_BIT_WIDTH_CLKS.
+ */
+#define WS2812_MAX_SPI_CLOCKS_PER_LED_BIT (4)
+/* The number of bytes needed in the SPI DMA buffer to represent one LED worth of 
+ * brightness values.*/
+#define WS2812_MAX_SPI_BYTES_PER_LED      (WS2812_MAX_SPI_CLOCKS_PER_LED_BIT * 3)    
+/* A macro to help the user in their sketch define the size of the SPI DMA buffer */
+#define CBWS2812PATBUF(__cDevices)        (WS2812_MAX_SPI_BYTES_PER_LED * __cDevices)
+/* Default total, 1 high and 0 high clock counts. Can be over-ridden on begin() */
+#define WS2812_DEFAULT_BIT_WIDTH_CLKS      4  // 1332nS  
+#define WS2812_DEFAULT_BIT_1_HIGH_CLKS     1  //  333nS
+#define WS2812_DEFAULT_BIT_0_HIGH_CLKS     2  //  666nS
 
 class WS2812 {
    
@@ -83,7 +123,14 @@ public:
     WS2812();
     ~WS2812();
 
-    bool begin(uint32_t cDevices, uint8_t * pPatternBuffer, uint32_t cbPatternBuffer, bool fInvert=false);
+    bool begin(
+        uint32_t cDevices, 
+        uint8_t * pPatternBuffer, 
+        uint32_t cbPatternBuffer, 
+        bool fInvert = false,
+        uint16_t cBitWidth = WS2812_DEFAULT_BIT_WIDTH_CLKS, 
+        uint16_t cBit1High = WS2812_DEFAULT_BIT_1_HIGH_CLKS, 
+        uint16_t cBit0High = WS2812_DEFAULT_BIT_0_HIGH_CLKS);
     bool updateLEDs(GRB rgGRB[], uint32_t cPass = 5);
     void abortUpdate(void);
     void end(void);
@@ -109,6 +156,9 @@ private:
     uint32_t        _iBit;
     GRB *           _pGRB;
     UST             _updateState;
+    uint8_t         _iBitSPIClocks;         // Total number of SPI clocks for a 1 or a 0 bit
+    uint8_t         _iBit1SPIClocksHigh;    // Number of SPI clocks for a 1 bit high period
+    uint8_t         _iBit0SPIClocksHigh;    // Number of SPI clocks for a 0 bit high period
 
     void init(void);
     void applyGRB(GRB& grb);

--- a/examples/LBling/LBling.ino
+++ b/examples/LBling/LBling.ino
@@ -70,7 +70,7 @@
 /************************************************************************/
 #include <WS2812.h>
 
-#define CDEVICES 20
+#define CDEVICES 144
 
 WS2812::GRB rgGRB[CDEVICES] =
 {
@@ -111,7 +111,7 @@ typedef enum {
 
 STATE state = LOADPAT;
 uint32_t tWaitShift = 0;
-#define MSSHIFT 250
+#define MSSHIFT 25
 
 /***    void setup()
  *
@@ -139,6 +139,7 @@ void setup()
 
     ws2812.begin(CDEVICES, rgbPatternBuffer, sizeof(rgbPatternBuffer), false);
     tWaitShift = millis();
+    mapPps(29, PPS_OUT_SDO2);
 }
 
 /***    void loop()


### PR DESCRIPTION
This is an updated version of the library, with better timing and lower RAM usage. Works on 48MHz as well as 80MHz boards.